### PR TITLE
[Fix] Device name property mapping

### DIFF
--- a/src/Netatmo/Models/Client/Air/HomesCoachs/Devices.cs
+++ b/src/Netatmo/Models/Client/Air/HomesCoachs/Devices.cs
@@ -48,7 +48,7 @@ namespace Netatmo.Models.Client.Air.HomesCoachs
         [JsonProperty("last_upgrade")] 
         public Instant LastUpgrade { get; set; }
         
-        [JsonProperty("name")] 
+        [JsonProperty("station_name")] 
         public string Name { get; set; }
 
         [JsonProperty("wifi_status")] 

--- a/src/Netatmo/Netatmo.csproj
+++ b/src/Netatmo/Netatmo.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <Version>1.3.2</Version>
+        <Version>1.3.3</Version>
         <TargetFrameworks>netcoreapp2.2;netcoreapp2.1;netstandard2.0</TargetFrameworks>
         <PackageId>Netatmo</PackageId>
         <Authors>Luc FASQUELLE</Authors>


### PR DESCRIPTION
Device name is not mapped from Json due to propertyName missmatching.

See NetAtmo doc:
https://dev.netatmo.com/resources/technical/reference/weather/getstationsdata