### PR TITLE
fix setthermmode url

### DIFF
--- a/src/Netatmo.Tests/EnergyClient.cs
+++ b/src/Netatmo.Tests/EnergyClient.cs
@@ -279,7 +279,7 @@ namespace Netatmo.Tests
             await sut.SetThermMode(homeId, mode);
 
             httpTest
-                .ShouldHaveCalled("https://api.netatmo.com/api/setroomthermmode")
+                .ShouldHaveCalled("https://api.netatmo.com/api/setthermmode")
                 .WithVerb(HttpMethod.Post)
                 .WithOAuthBearerToken(accessToken)
                 .WithContentType("application/json").WithRequestJson(new SetThermModeRequest {HomeId = homeId, Mode = mode})

--- a/src/Netatmo/EnergyClient.cs
+++ b/src/Netatmo/EnergyClient.cs
@@ -52,7 +52,7 @@ namespace Netatmo
         {
             return await baseUrl
                 .ConfigureRequest(Configuration.ConfigureRequest)
-                .AppendPathSegment("/api/setroomthermmode")
+                .AppendPathSegment("/api/setthermmode")
                 .WithOAuthBearerToken(credentialManager.AccessToken)
                 .PostJsonAsync(new SetThermModeRequest
                 {


### PR DESCRIPTION
As per the documentation:
https://dev.netatmo.com/apidocumentation/energy#setthermmode

the url to set thermal mode of the thermostat is setthermmode.
Tested with a real device.