### PR TITLE
Quick Fix for #167

### DIFF
--- a/src/Netatmo/Client.cs
+++ b/src/Netatmo/Client.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using NodaTime;
 
 namespace Netatmo
@@ -20,12 +21,18 @@ namespace Netatmo
 
         public Task GenerateToken(string username, string password, Scope[] scopes = null)
         {
+            Console.WriteLine("Client credentials grant type is deprecated since october 2022 and will not work!");
             return CredentialManager.GenerateToken(username, password, scopes);
         }
         
-        public void ProvideOAuth2Token(string oauth2Token)
+        public void ProvideOAuth2Token(string accessToken)
         {
-            CredentialManager.ProvideOAuth2Token(oauth2Token);
+            CredentialManager.ProvideOAuth2Token(accessToken);
+        }
+        
+        public void ProvideOAuth2Token(string accessToken, string refreshToken)
+        {
+            CredentialManager.ProvideOAuth2Token(accessToken, refreshToken);
         }
 
         public Task RefreshToken()

--- a/src/Netatmo/CredentialManager.cs
+++ b/src/Netatmo/CredentialManager.cs
@@ -45,17 +45,22 @@ namespace Netatmo
 
             CredentialToken = new CredentialToken(token, clock);
         }
-
-        public void ProvideOAuth2Token(string oauth2Token)
+        
+        public void ProvideOAuth2Token(string accessToken, string refreshToken)
         {
             var appToken = new Token()
             {
-                AccessToken = oauth2Token,
-                RefreshToken = null,
+                AccessToken = accessToken,
+                RefreshToken = refreshToken,
                 ExpiresIn = 20
             };
 
             CredentialToken = new CredentialToken(appToken, clock);
+        }
+
+        public void ProvideOAuth2Token(string accessToken)
+        {
+            ProvideOAuth2Token(accessToken, null);
         }
 
         public async Task RefreshToken()

--- a/src/Netatmo/IClient.cs
+++ b/src/Netatmo/IClient.cs
@@ -9,7 +9,7 @@ namespace Netatmo
         IAirClient Air { get; }
         ICredentialManager CredentialManager { get; }
         Task GenerateToken(string username, string password, Scope[] scopes = null);
-        void ProvideOAuth2Token(string oauth2Token);
+        void ProvideOAuth2Token(string accessToken);
         Task RefreshToken();
     }
 }

--- a/src/Netatmo/ICredentialManager.cs
+++ b/src/Netatmo/ICredentialManager.cs
@@ -8,7 +8,8 @@ namespace Netatmo
         CredentialToken CredentialToken { get; }
         string AccessToken { get; }
         Task GenerateToken(string username, string password, Scope[] scopes = null);
-        void ProvideOAuth2Token(string oauth2Token);
+        void ProvideOAuth2Token(string accessToken);
+        void ProvideOAuth2Token(string accessToken, string refreshToken);
         Task RefreshToken();
     }
 }


### PR DESCRIPTION
Extend CredentialManager to accept refresh_token and add warning message for deprecated GenerateToken

Example usage:

```csharp
var clientId = "myClientId";
var clientSecret = "myClientSecret";
var accessToken = "myAccessToken";
var refreshToken = "myRefreshToken";

var client = new Client(
    SystemClock.Instance, "https://api.netatmo.com/",
    clientId,
    clientSecret);

client.ProvideOAuth2Token(accessToken, refreshToken);
await client.RefreshToken();
var stationsData = await client.Weather.GetStationsData();
```