### PR TITLE
Migrate project to .NET 9

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,7 +44,7 @@ jobs:
         displayName: "Use .NET Core SDK Tool Installer"
         inputs:
           packageType: "sdk"
-          version: "3.1.101"
+          version: "9.0.100"
       - script: dotnet restore src
         displayName: Restore packages
       - script: |

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.401",
+    "version": "9.0.100",
     "rollForward": "latestFeature"
   }
 }

--- a/src/Netatmo/Netatmo.csproj
+++ b/src/Netatmo/Netatmo.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <IsPackable>true</IsPackable>

--- a/tests/Netatmo.Tests/Netatmo.Tests.csproj
+++ b/tests/Netatmo.Tests/Netatmo.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <IsPackable>False</IsPackable>

--- a/tests/Netatmo.Tests/Netatmo.Tests.csproj
+++ b/tests/Netatmo.Tests/Netatmo.Tests.csproj
@@ -15,18 +15,20 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AutoFixture" Version="4.18.1"/>
-        <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.18.1"/>
-        <PackageReference Include="AutoFixture.Xunit2" Version="4.18.1"/>
-        <PackageReference Include="FluentAssertions" Version="6.12.0"/>
+        <PackageReference Include="AutoFixture" Version="4.18.1" />
+        <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
+        <PackageReference Include="AutoFixture.Xunit2" Version="4.18.1" />
+        <PackageReference Include="FluentAssertions" Version="6.12.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
-        <PackageReference Include="NodaTime.Testing" Version="3.1.11"/>
-        <PackageReference Include="NSubstitute" Version="5.1.0"/>
+        <PackageReference Include="NodaTime.Testing" Version="3.1.11" />
+        <PackageReference Include="NSubstitute" Version="5.1.0" />
         <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.17">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="xunit" Version="2.9.0"/>
+        <PackageReference Include="System.Net.Http" Version="4.3.4" />
+        <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+        <PackageReference Include="xunit" Version="2.9.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -34,12 +36,12 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Using Include="FluentAssertions"/>
-        <Using Include="NSubstitute"/>
-        <Using Include="Xunit"/>
+        <Using Include="FluentAssertions" />
+        <Using Include="NSubstitute" />
+        <Using Include="Xunit" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\src\Netatmo\Netatmo.csproj"/>
+        <ProjectReference Include="..\..\src\Netatmo\Netatmo.csproj" />
     </ItemGroup>
 </Project>

--- a/tests/TestApp/TestApp.csproj
+++ b/tests/TestApp/TestApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <IsPackable>false</IsPackable>


### PR DESCRIPTION
Migrate the project to .NET 9.

* **Project Files**
  - Update `src/Netatmo/Netatmo.csproj` to target .NET 9.
  - Update `tests/Netatmo.Tests/Netatmo.Tests.csproj` to target .NET 9.

* **Azure Pipelines**
  - Update `azure-pipelines.yml` to use .NET 9 SDK version 9.0.100.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Riges/Netatmo/pull/172?shareId=7e4f9866-0968-4bf7-9cdc-9ee875c58d97).