### PR TITLE
ci: Refacto of ci and fix warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     name: Create Package nuget
     needs: test
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.event.created == true && github.event.compare != '' && github.ref != ''
+    if: startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Dump GitHub context
         env:
@@ -59,24 +59,11 @@ jobs:
           name: Netatmo.${{ env.TAG }}.nupkg
           path: src/Netatmo/bin/Release/Netatmo.${{ env.TAG }}.nupkg
       - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ env.TAG }}
-          release_name: Release ${{ env.TAG }}
-          draft: false
-          prerelease: false
-      - name: Upload Release Asset
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/
-          asset_path: src/Netatmo/bin/Release/Netatmo.${{ env.TAG }}.nupkg
-          asset_name: Netatmo.${{ env.TAG }}.nupkg
-          asset_content_type: application/zip
+          files: |
+            src/Netatmo/bin/Release/Netatmo.${{ env.TAG }}.nupkg
+          name: Release ${{ env.TAG }}
+          generate_release_notes: true
       - name: Push package
         run: dotnet nuget push src/Netatmo/bin/Release/Netatmo.$TAG.nupkg -k ${{ secrets.NUGET_ORG_KEY }} -s https://api.nuget.org/v3/index.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
         run: dotnet restore
       - name: Test
         run: dotnet test --configuration Release
+
   build:
     name: Create Package nuget
     needs: test
@@ -41,8 +42,8 @@ jobs:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: echo "$GITHUB_CONTEXT"
       - name: Get the version
-        id: vars
-        run: echo ::set-output name=tag::$(echo ${GITHUB_REF:10})
+        run: |
+          echo "TAG=${GITHUB_REF:10}" >> $GITHUB_ENV
       - uses: actions/checkout@v4
       - name: Setup dotnet
         uses: actions/setup-dotnet@v4
@@ -51,20 +52,20 @@ jobs:
       - name: Restore packages
         run: dotnet restore
       - name: Build and create package nuget
-        run: dotnet pack -c Release -p:PackageVersion=${{steps.vars.outputs.tag}}
+        run: dotnet pack -c Release -p:PackageVersion=$TAG
       - name: Publish artifact
         uses: actions/upload-artifact@master
         with:
-          name: Netatmo.${{steps.vars.outputs.tag}}.nupkg
-          path: src/Netatmo/bin/Release/Netatmo.${{steps.vars.outputs.tag}}.nupkg
+          name: Netatmo.${{ env.TAG }}.nupkg
+          path: src/Netatmo/bin/Release/Netatmo.${{ env.TAG }}.nupkg
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{steps.vars.outputs.tag}}
-          release_name: Release ${{steps.vars.outputs.tag}}
+          tag_name: ${{ env.TAG }}
+          release_name: Release ${{ env.TAG }}
           draft: false
           prerelease: false
       - name: Upload Release Asset
@@ -73,9 +74,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: src/Netatmo/bin/Release/Netatmo.${{steps.vars.outputs.tag}}.nupkg
-          asset_name: Netatmo.${{steps.vars.outputs.tag}}.nupkg
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/
+          asset_path: src/Netatmo/bin/Release/Netatmo.${{ env.TAG }}.nupkg
+          asset_name: Netatmo.${{ env.TAG }}.nupkg
           asset_content_type: application/zip
       - name: Push package
-        run: dotnet nuget push src/Netatmo/bin/Release/Netatmo.${{steps.vars.outputs.tag}}.nupkg -k ${{ secrets.NUGET_ORG_KEY }} -s https://api.nuget.org/v3/index.json
+        run: dotnet nuget push src/Netatmo/bin/Release/Netatmo.$TAG.nupkg -k ${{ secrets.NUGET_ORG_KEY }} -s https://api.nuget.org/v3/index.json

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,28 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  test:
+    name: Test on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+      - name: Restore packages
+        run: dotnet restore
+      - name: Test
+        run: dotnet test --configuration Release


### PR DESCRIPTION
Refactor the CI workflow to utilize environment variables for versioning, replace deprecated actions, and split the testing workflow for better clarity and maintainability.