### PR TITLE
chore: Add permissions section for GitHub release workflow

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,4 +1,3 @@
-commitish: master
 name-template: "Release $RESOLVED_VERSION"
 tag-template: "v$RESOLVED_VERSION"
 template: |

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,8 +6,6 @@ on:
       - master
   # pull_request event is required only for autolabeler
   pull_request:
-    # Only following types are handled by the action, but one can default to all as well
-    types: [opened, reopened, synchronize]
 
 jobs:
   update_release_draft:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,8 +6,8 @@ on:
       - master
   # pull_request event is required only for autolabeler
   pull_request:
-    branches:
-      - master
+    # Only following types are handled by the action, but one can default to all as well
+    types: [opened, reopened, synchronize]
 
 jobs:
   update_release_draft:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -20,5 +20,7 @@ jobs:
       pull-requests: write
     steps:
       - uses: release-drafter/release-drafter@v6
+        with:
+          disable-autolabeler: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - v*.*.*
 
+permissions:
+  # write permission is required to create a github release
+  contents: write
+
 jobs:
   Publish:
     name: Create NuGet Package

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
 
 jobs:
   test:


### PR DESCRIPTION
This pull request includes updates to the release configuration and workflow files to improve the release process and permissions.

Improvements to release configuration:

* [`.github/release-drafter.yml`](diffhunk://#diff-101bec72d0f1f84e7290d113531bbd8c6aa355cdc9f456df255544bc0a2da0eaL1): Removed the `commitish` field to streamline the release drafter configuration.

Enhancements to workflow permissions:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R8-R11): Added `permissions` section to grant write access to `contents`, which is required for creating a GitHub release.